### PR TITLE
Rewrite homepage to use square logo and focus on 'vibe the web' concept

### DIFF
--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,37 +1,55 @@
 import { HydrateClient } from "@/trpc/server";
 import { auth, signIn } from "@/server/auth";
 import { WelcomeFlow } from "@/components/welcome-flow";
+import Image from "next/image";
 
 export default async function WelcomePage() {
   const session = await auth();
 
   if (!session?.user) {
     return (
-      <main className="container mx-auto p-8 min-h-screen bg-white">
-        <div className="max-w-md mx-auto mt-8">
-          <h1 className="text-3xl font-bold mb-6 text-gray-900 text-center">
-            VibeSurfing - Web Search Spreadsheets
-          </h1>
-          <div className="bg-gray-50 rounded-lg p-8 text-center">
-            <h2 className="text-xl font-semibold mb-4 text-gray-800">
-              Sign in to continue
-            </h2>
-            <p className="text-gray-600 mb-6">
-              You need to sign in to create and manage your search spreadsheets.
-            </p>
-            <form
-              action={async () => {
-                "use server";
-                await signIn("google");
-              }}
-            >
-              <button
-                type="submit"
-                className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+      <main className="min-h-screen bg-gradient-to-br from-cyan-50 via-blue-50 to-indigo-100 flex items-center justify-center p-8">
+        <div className="max-w-md mx-auto">
+          <div className="bg-white rounded-2xl shadow-xl p-8 text-center space-y-6">
+            <div className="flex justify-center">
+              <Image
+                src="/logo.png"
+                alt="VibeSurfing - Vibe the Web"
+                width={250}
+                height={250}
+                priority
+                className="rounded-lg"
+              />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold bg-gradient-to-r from-cyan-600 to-blue-600 bg-clip-text text-transparent mb-2">
+                Vibe the Web
+              </h1>
+              <p className="text-gray-600 mb-6">
+                AI-powered websets that surf the internet for you
+              </p>
+            </div>
+            <div className="bg-gradient-to-br from-cyan-50 to-blue-50 rounded-lg p-6">
+              <h2 className="text-xl font-semibold mb-3 text-gray-800">
+                Ready to catch some waves?
+              </h2>
+              <p className="text-gray-600 mb-6">
+                Sign in to start vibing with websets
+              </p>
+              <form
+                action={async () => {
+                  "use server";
+                  await signIn("google");
+                }}
               >
-                Sign in with Google
-              </button>
-            </form>
+                <button
+                  type="submit"
+                  className="bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-700 hover:to-blue-700 text-white font-medium py-3 px-6 rounded-lg transition-all shadow-lg hover:shadow-xl"
+                >
+                  Sign in with Google
+                </button>
+              </form>
+            </div>
           </div>
         </div>
       </main>

--- a/src/components/welcome-flow.tsx
+++ b/src/components/welcome-flow.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { api } from "@/trpc/react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { COLUMN_TEMPLATES, type TemplateType, getDefaultSheetName } from "@/server/templates/column-templates";
 
 export function WelcomeFlow() {
@@ -48,24 +49,39 @@ export function WelcomeFlow() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-8">
+    <div className="min-h-screen bg-gradient-to-br from-cyan-50 via-blue-50 to-indigo-100 flex items-center justify-center p-8">
       <div className="max-w-4xl w-full bg-white rounded-2xl shadow-xl p-8 space-y-8">
-        <div className="text-center">
-          <h1 className="text-4xl font-bold text-gray-900 mb-2">
-            Welcome to VibeSurfing
-          </h1>
-          <p className="text-gray-600">
-            Search the internet using spreadsheets powered by AI
-          </p>
+        <div className="text-center space-y-6">
+          <div className="flex justify-center">
+            <Image
+              src="/logo.png"
+              alt="VibeSurfing - Vibe the Web"
+              width={300}
+              height={300}
+              priority
+              className="rounded-lg"
+            />
+          </div>
+          <div>
+            <h1 className="text-4xl font-bold bg-gradient-to-r from-cyan-600 to-blue-600 bg-clip-text text-transparent mb-3">
+              Vibe the Web
+            </h1>
+            <p className="text-lg text-gray-700 mb-2">
+              Ride the waves of information with websets
+            </p>
+            <p className="text-gray-600">
+              AI-powered spreadsheets that surf the internet for you
+            </p>
+          </div>
         </div>
 
         <div className="space-y-6">
-          <div className="border-2 border-gray-200 rounded-xl p-6 hover:border-blue-400 transition-colors">
+          <div className="border-2 border-cyan-200 rounded-xl p-6 hover:border-cyan-400 transition-colors bg-gradient-to-br from-white to-cyan-50/30">
             <h2 className="text-2xl font-semibold text-gray-800 mb-4">
-              📋 Create New Sheet from Template
+              🏄 Catch a Wave - Start a New Webset
             </h2>
             <p className="text-gray-600 mb-6">
-              Start with a pre-configured template optimized for specific research tasks
+              Pick your vibe and let AI surf the web for you
             </p>
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -114,12 +130,12 @@ export function WelcomeFlow() {
             </div>
           </div>
 
-          <div className="border-2 border-gray-200 rounded-xl p-6 hover:border-green-400 transition-colors">
+          <div className="border-2 border-blue-200 rounded-xl p-6 hover:border-blue-400 transition-colors bg-gradient-to-br from-white to-blue-50/30">
             <h2 className="text-2xl font-semibold text-gray-800 mb-4">
-              📂 Open Existing Sheet
+              🌊 Your Websets
             </h2>
             <p className="text-gray-600 mb-4">
-              Continue working on a sheet you&apos;ve already created
+              Jump back into your saved websets and keep vibing
             </p>
 
             {sheets && sheets.length > 0 ? (
@@ -154,7 +170,7 @@ export function WelcomeFlow() {
               </div>
             ) : (
               <div className="text-center py-8 text-gray-500">
-                <p>No sheets yet. Create your first one above!</p>
+                <p>No websets yet. Catch your first wave above!</p>
               </div>
             )}
           </div>


### PR DESCRIPTION
- Add square logo from public/logo.png to welcome pages
- Update messaging to focus on "vibe the web" and "websets"
- Replace "sheets" terminology with "websets" throughout
- Update UI with surfing-themed copy and gradients
- Change color scheme from blue to cyan/blue to match logo aesthetic
- Add surf-themed CTAs: "Catch a Wave", "Your Websets", etc.